### PR TITLE
Nickname and invariant fix

### DIFF
--- a/src/main/java/dk/cs/aau/huppaal/presentations/DropDownMenu.java
+++ b/src/main/java/dk/cs/aau/huppaal/presentations/DropDownMenu.java
@@ -390,9 +390,6 @@ public class DropDownMenu {
                 return;
             }
 
-            // If we do not do this, the method below will be called twice
-            if (!(event.getTarget() instanceof StackPane)) return;
-
             mouseEventConsumer.accept(event);
         });
 


### PR DESCRIPTION
The ´´Add Nickname´´ and ´´Add Invariant´´ list items in the location context menu did not call the expected methods. This has been mixed by removing the check that avoided the method being called twice. I expect that was due to a bug in Java 8, fixed in Java 11.