### PR TITLE
Dragging tags outside of component fixed

### DIFF
--- a/src/main/java/dk/cs/aau/huppaal/presentations/TagPresentation.java
+++ b/src/main/java/dk/cs/aau/huppaal/presentations/TagPresentation.java
@@ -1,6 +1,7 @@
 package dk.cs.aau.huppaal.presentations;
 
 import dk.cs.aau.huppaal.abstractions.Component;
+import dk.cs.aau.huppaal.abstractions.Nail;
 import dk.cs.aau.huppaal.controllers.CanvasController;
 import dk.cs.aau.huppaal.utility.UndoRedoStack;
 import dk.cs.aau.huppaal.utility.colors.Color;
@@ -213,18 +214,34 @@ public class TagPresentation extends StackPane {
                 textField.requestFocus();
                 textField.requestFocus(); // This needs to be done twice because of reasons
             }
+            
+            //Handle constraints for guards, selects, synchronizations, and updates
+            if(getParent() instanceof NailPresentation){
+                if(getParent().localToParent(getBoundsInParent()).getCenterX() > getComponent().widthProperty().doubleValue() - textField.getWidth()) {
+                    setTranslateX(getTranslateX() + getComponent().widthProperty().doubleValue() - textField.getWidth() - getParent().localToParent(getBoundsInParent()).getCenterX());
+                } else if (getParent().localToParent(getBoundsInParent()).getCenterX() - textField.getWidth() < 0) {
+                    setTranslateX(getTranslateX() - (getParent().localToParent(getBoundsInParent()).getCenterX() - textField.getWidth()));
+                }
 
-            if(getParent().localToParent(getBoundsInParent()).getCenterX() > getComponent().widthProperty().doubleValue() - textField.getWidth()) {
-                setTranslateX(getTranslateX() + getComponent().widthProperty().doubleValue() - textField.getWidth() - getParent().localToParent(getBoundsInParent()).getCenterX());
-            } else if (getParent().localToParent(getBoundsInParent()).getCenterX() - textField.getWidth() < 0) {
-                setTranslateX(getTranslateX() - (getParent().localToParent(getBoundsInParent()).getCenterX() - textField.getWidth()));
+                if(getParent().localToParent(getBoundsInParent()).getCenterY() > getComponent().heightProperty().doubleValue() - textField.getHeight()) {
+                    setTranslateY(getTranslateY() + getComponent().heightProperty().doubleValue() - textField.getHeight() - getParent().localToParent(getBoundsInParent()).getCenterY());
+                } else if (getParent().localToParent(getBoundsInParent()).getCenterY() - textField.getHeight() - GRID_SIZE * 2 < 0) {
+                    setTranslateY(getTranslateY() - (getParent().localToParent(getBoundsInParent()).getCenterY() - textField.getHeight() - GRID_SIZE * 2));
+                }
+            } else {
+                if(getParent().getParent().localToParent(getBoundsInParent()).getCenterX() > getComponent().widthProperty().doubleValue() - textField.getWidth()) {
+                    setTranslateX(getTranslateX() + getComponent().widthProperty().doubleValue() - textField.getWidth() - getParent().getParent().localToParent(getBoundsInParent()).getCenterX());
+                } else if (getParent().getParent().localToParent(getBoundsInParent()).getCenterX() - textField.getWidth() < 0) {
+                    setTranslateX(getTranslateX() - (getParent().getParent().localToParent(getBoundsInParent()).getCenterX() - textField.getWidth()));
+                }
+
+                if(getParent().getParent().localToParent(getBoundsInParent()).getCenterY() > getComponent().heightProperty().doubleValue() - textField.getHeight()) {
+                    setTranslateY(getTranslateY() + getComponent().heightProperty().doubleValue() - textField.getHeight() - getParent().getParent().localToParent(getBoundsInParent()).getCenterY());
+                } else if (getParent().getParent().localToParent(getBoundsInParent()).getCenterY() - textField.getHeight() - GRID_SIZE * 2 < 0) {
+                    setTranslateY(getTranslateY() - (getParent().getParent().localToParent(getBoundsInParent()).getCenterY() - textField.getHeight() - GRID_SIZE * 2));
+                }
             }
 
-            if(getParent().localToParent(getBoundsInParent()).getCenterY() > getComponent().heightProperty().doubleValue() - textField.getHeight()) {
-                setTranslateY(getTranslateY() + getComponent().heightProperty().doubleValue() - textField.getHeight() - getParent().localToParent(getBoundsInParent()).getCenterY());
-            } else if (getParent().localToParent(getBoundsInParent()).getCenterY() - textField.getHeight() - GRID_SIZE * 2 < 0) {
-                setTranslateY(getTranslateY() - (getParent().localToParent(getBoundsInParent()).getCenterY() - textField.getHeight() - GRID_SIZE * 2));
-            }
 
         });
 

--- a/src/main/java/dk/cs/aau/huppaal/presentations/TagPresentation.java
+++ b/src/main/java/dk/cs/aau/huppaal/presentations/TagPresentation.java
@@ -214,7 +214,7 @@ public class TagPresentation extends StackPane {
                 textField.requestFocus();
                 textField.requestFocus(); // This needs to be done twice because of reasons
             }
-            
+
             //Handle constraints for guards, selects, synchronizations, and updates
             if(getParent() instanceof NailPresentation){
                 if(getParent().localToParent(getBoundsInParent()).getCenterX() > getComponent().widthProperty().doubleValue() - textField.getWidth()) {
@@ -228,7 +228,10 @@ public class TagPresentation extends StackPane {
                 } else if (getParent().localToParent(getBoundsInParent()).getCenterY() - textField.getHeight() - GRID_SIZE * 2 < 0) {
                     setTranslateY(getTranslateY() - (getParent().localToParent(getBoundsInParent()).getCenterY() - textField.getHeight() - GRID_SIZE * 2));
                 }
-            } else {
+            }
+            
+            //Handle constraints for location names
+            else {
                 if(getParent().getParent().localToParent(getBoundsInParent()).getCenterX() > getComponent().widthProperty().doubleValue() - textField.getWidth()) {
                     setTranslateX(getTranslateX() + getComponent().widthProperty().doubleValue() - textField.getWidth() - getParent().getParent().localToParent(getBoundsInParent()).getCenterX());
                 } else if (getParent().getParent().localToParent(getBoundsInParent()).getCenterX() - textField.getWidth() < 0) {

--- a/src/main/java/dk/cs/aau/huppaal/presentations/TagPresentation.java
+++ b/src/main/java/dk/cs/aau/huppaal/presentations/TagPresentation.java
@@ -9,9 +9,11 @@ import com.jfoenix.controls.JFXTextField;
 import javafx.application.Platform;
 import javafx.beans.binding.When;
 import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.SimpleDoubleProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.beans.property.StringProperty;
 import javafx.beans.value.ObservableBooleanValue;
+import javafx.beans.value.ObservableDoubleValue;
 import javafx.fxml.FXMLLoader;
 import javafx.fxml.JavaFXBuilderFactory;
 import javafx.geometry.Insets;
@@ -210,6 +212,18 @@ public class TagPresentation extends StackPane {
                 textField.setMouseTransparent(false);
                 textField.requestFocus();
                 textField.requestFocus(); // This needs to be done twice because of reasons
+            }
+
+            if(getParent().localToParent(getBoundsInParent()).getCenterX() > getComponent().widthProperty().doubleValue() - textField.getWidth()) {
+                setTranslateX(getTranslateX() + getComponent().widthProperty().doubleValue() - textField.getWidth() - getParent().localToParent(getBoundsInParent()).getCenterX());
+            } else if (getParent().localToParent(getBoundsInParent()).getCenterX() - textField.getWidth() < 0) {
+                setTranslateX(getTranslateX() - (getParent().localToParent(getBoundsInParent()).getCenterX() - textField.getWidth()));
+            }
+
+            if(getParent().localToParent(getBoundsInParent()).getCenterY() > getComponent().heightProperty().doubleValue() - textField.getHeight()) {
+                setTranslateY(getTranslateY() + getComponent().heightProperty().doubleValue() - textField.getHeight() - getParent().localToParent(getBoundsInParent()).getCenterY());
+            } else if (getParent().localToParent(getBoundsInParent()).getCenterY() - textField.getHeight() - GRID_SIZE * 2 < 0) {
+                setTranslateY(getTranslateY() - (getParent().localToParent(getBoundsInParent()).getCenterY() - textField.getHeight() - GRID_SIZE * 2));
             }
 
         });

--- a/src/main/java/dk/cs/aau/huppaal/presentations/TagPresentation.java
+++ b/src/main/java/dk/cs/aau/huppaal/presentations/TagPresentation.java
@@ -19,6 +19,7 @@ import javafx.fxml.FXMLLoader;
 import javafx.fxml.JavaFXBuilderFactory;
 import javafx.geometry.Insets;
 import javafx.scene.Cursor;
+import javafx.scene.Node;
 import javafx.scene.control.Label;
 import javafx.scene.layout.StackPane;
 import javafx.scene.shape.LineTo;
@@ -215,34 +216,28 @@ public class TagPresentation extends StackPane {
                 textField.requestFocus(); // This needs to be done twice because of reasons
             }
 
-            //Handle constraints for guards, selects, synchronizations, and updates
+            Node parent;
+
             if(getParent() instanceof NailPresentation){
-                if(getParent().localToParent(getBoundsInParent()).getCenterX() > getComponent().widthProperty().doubleValue() - textField.getWidth()) {
-                    setTranslateX(getTranslateX() + getComponent().widthProperty().doubleValue() - textField.getWidth() - getParent().localToParent(getBoundsInParent()).getCenterX());
-                } else if (getParent().localToParent(getBoundsInParent()).getCenterX() - textField.getWidth() < 0) {
-                    setTranslateX(getTranslateX() - (getParent().localToParent(getBoundsInParent()).getCenterX() - textField.getWidth()));
-                }
-
-                if(getParent().localToParent(getBoundsInParent()).getCenterY() > getComponent().heightProperty().doubleValue() - textField.getHeight()) {
-                    setTranslateY(getTranslateY() + getComponent().heightProperty().doubleValue() - textField.getHeight() - getParent().localToParent(getBoundsInParent()).getCenterY());
-                } else if (getParent().localToParent(getBoundsInParent()).getCenterY() - textField.getHeight() - GRID_SIZE * 2 < 0) {
-                    setTranslateY(getTranslateY() - (getParent().localToParent(getBoundsInParent()).getCenterY() - textField.getHeight() - GRID_SIZE * 2));
-                }
+                //Get the correct parent for guards, selects, synchronizations, and updates
+                parent = getParent();
+            } else {
+                //Gte the correct parent for location names
+                parent = getParent().getParent();
             }
-            
-            //Handle constraints for location names
-            else {
-                if(getParent().getParent().localToParent(getBoundsInParent()).getCenterX() > getComponent().widthProperty().doubleValue() - textField.getWidth()) {
-                    setTranslateX(getTranslateX() + getComponent().widthProperty().doubleValue() - textField.getWidth() - getParent().getParent().localToParent(getBoundsInParent()).getCenterX());
-                } else if (getParent().getParent().localToParent(getBoundsInParent()).getCenterX() - textField.getWidth() < 0) {
-                    setTranslateX(getTranslateX() - (getParent().getParent().localToParent(getBoundsInParent()).getCenterX() - textField.getWidth()));
-                }
 
-                if(getParent().getParent().localToParent(getBoundsInParent()).getCenterY() > getComponent().heightProperty().doubleValue() - textField.getHeight()) {
-                    setTranslateY(getTranslateY() + getComponent().heightProperty().doubleValue() - textField.getHeight() - getParent().getParent().localToParent(getBoundsInParent()).getCenterY());
-                } else if (getParent().getParent().localToParent(getBoundsInParent()).getCenterY() - textField.getHeight() - GRID_SIZE * 2 < 0) {
-                    setTranslateY(getTranslateY() - (getParent().getParent().localToParent(getBoundsInParent()).getCenterY() - textField.getHeight() - GRID_SIZE * 2));
-                }
+            //Handle the horizontal placement of the tag
+            if(parent.localToParent(getBoundsInParent()).getCenterX() > getComponent().widthProperty().doubleValue() - textField.getWidth()) {
+                setTranslateX(getTranslateX() + getComponent().widthProperty().doubleValue() - textField.getWidth() - parent.localToParent(getBoundsInParent()).getCenterX());
+            } else if (parent.localToParent(getBoundsInParent()).getCenterX() - textField.getWidth() < 0) {
+                setTranslateX(getTranslateX() - (parent.localToParent(getBoundsInParent()).getCenterX() - textField.getWidth()));
+            }
+
+            //Handle the vertical placement of the tag
+            if(parent.localToParent(getBoundsInParent()).getCenterY() > getComponent().heightProperty().doubleValue() - textField.getHeight()) {
+                setTranslateY(getTranslateY() + getComponent().heightProperty().doubleValue() - textField.getHeight() - parent.localToParent(getBoundsInParent()).getCenterY());
+            } else if (parent.localToParent(getBoundsInParent()).getCenterY() - textField.getHeight() - GRID_SIZE * 2 < 0) {
+                setTranslateY(getTranslateY() - (parent.localToParent(getBoundsInParent()).getCenterY() - textField.getHeight() - GRID_SIZE * 2));
             }
 
 


### PR DESCRIPTION
This makes sure that the tags for guards, selections, and so on are always snapped to a location inside the component, when they are dragged outside the component