### PR TITLE
Fix: dont escape utf8 characters when saving

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ mainClassName = 'HUPPAAL'
 
 allprojects {
     group = 'dk.cs.aau.huppaal'
-    version = '1.3.0'
+    version = '1.3.1'
 }
 
 def getGitCommitSha = { ->

--- a/src/main/java/dk/cs/aau/huppaal/HUPPAAL.java
+++ b/src/main/java/dk/cs/aau/huppaal/HUPPAAL.java
@@ -37,6 +37,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.Writer;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.*;
@@ -101,9 +102,9 @@ public class HUPPAAL extends Application {
                 java.nio.file.Files.delete(p);
 
             // Save components
-            var gson = new GsonBuilder().setPrettyPrinting().create();
+            var gson = new GsonBuilder().disableHtmlEscaping().setPrettyPrinting().create();
             for(var c : HUPPAAL.getProject().getComponents()) {
-                var writer = new FileWriter(String.format(projectDirectory.getValue() + File.separator + "%s.json", c.getName()));
+                var writer = new FileWriter(String.format(projectDirectory.getValue() + File.separator + "%s.json", c.getName()), StandardCharsets.UTF_8);
                 gson.toJson(c.serialize(), writer);
                 writer.close();
             }
@@ -111,7 +112,7 @@ public class HUPPAAL extends Application {
             // Save queries
             var queries = new JsonArray();
             HUPPAAL.getProject().getQueries().forEach(query -> queries.add(query.serialize()));
-            var writer = new FileWriter(projectDirectory.getValue() + File.separator + "Queries.json");
+            var writer = new FileWriter(projectDirectory.getValue() + File.separator + "Queries.json", StandardCharsets.UTF_8);
             gson.toJson(queries, writer);
             writer.close();
 


### PR DESCRIPTION
# Fix: Dont escape utf8 characters in the `save` function
This PR fixes an issue where many characters would be escaped and would be very difficult for humans to read. Now the `save` function will save characters as humanly readable text.

Please note that this will affect all projects next time you save it.

## Example
**Old behavior**: When saving a project that has an `guard` with the value: 

`foo > 30`, it would save a json file `foo \u003e 30`.

**New behavior**: When saving a project that has an `guard` with the value:

`foo > 30`, it saves a json file `foo > 30`.