### PR TITLE
Feature: add a splashscreen/preloader to indicate loading progress

### DIFF
--- a/src/main/java/dk/cs/aau/huppaal/HUPPAALPreloader.java
+++ b/src/main/java/dk/cs/aau/huppaal/HUPPAALPreloader.java
@@ -40,9 +40,8 @@ public class HUPPAALPreloader extends Preloader {
 
     @Override
     public void handleApplicationNotification(PreloaderNotification info) {
-        if(info instanceof Notification ninfo) {
-            System.out.println(ninfo.getStage().name());
-            switch (ninfo.getStage()) {
+        if(info instanceof Notification notificationInfo) {
+            switch (notificationInfo.getStage()) {
                 case LOADING_PROJECT -> presentation.getController().statusLabel.setText("Loading Project...");
                 case INITALIZE_JFX -> presentation.getController().statusLabel.setText("Initializing JFX...");
                 case AFTER_INIT -> presentation.getController().statusLabel.setText("Finished init...");

--- a/src/main/java/dk/cs/aau/huppaal/HUPPAALPreloader.java
+++ b/src/main/java/dk/cs/aau/huppaal/HUPPAALPreloader.java
@@ -1,0 +1,56 @@
+package dk.cs.aau.huppaal;
+
+import dk.cs.aau.huppaal.presentations.PreloaderPresentation;
+import javafx.application.Platform;
+import javafx.application.Preloader;
+import javafx.scene.Scene;
+import javafx.stage.Stage;
+import javafx.stage.StageStyle;
+
+public class HUPPAALPreloader extends Preloader {
+    public enum LoadStage {
+        LOADING_PROJECT,
+        INITALIZE_JFX,
+        AFTER_INIT,
+        START_JFX,
+        AFTER_SHOW,
+        FINISHED
+    }
+    public static class Notification implements PreloaderNotification {
+        private final LoadStage stage;
+        public Notification(LoadStage stage) {
+            this.stage = stage;
+        }
+        public LoadStage getStage() {
+            return stage;
+        }
+    }
+    private Stage stage;
+    private PreloaderPresentation presentation;
+
+    @Override
+    public void start(Stage primaryStage) throws Exception {
+        stage = new Stage();
+        presentation = new PreloaderPresentation();
+        presentation.getController().projectNameLabel.setText(HUPPAAL.projectDirectory.getValue());
+        stage.setScene(new Scene(presentation));
+        stage.initStyle(StageStyle.UNDECORATED);
+        stage.show();
+    }
+
+    @Override
+    public void handleApplicationNotification(PreloaderNotification info) {
+        if(info instanceof Notification ninfo) {
+            System.out.println(ninfo.getStage().name());
+            switch (ninfo.getStage()) {
+                case LOADING_PROJECT -> presentation.getController().statusLabel.setText("Loading Project...");
+                case INITALIZE_JFX -> presentation.getController().statusLabel.setText("Initializing JFX...");
+                case AFTER_INIT -> presentation.getController().statusLabel.setText("Finished init...");
+                case START_JFX -> presentation.getController().statusLabel.setText("Starting JFX...");
+                case AFTER_SHOW -> stage.hide();
+                case FINISHED -> Platform.runLater(() -> presentation.getController().statusLabel.setText("Finished"));
+            }
+        }
+        super.handleApplicationNotification(info);
+    }
+}

--- a/src/main/java/dk/cs/aau/huppaal/controllers/HUPPAALController.java
+++ b/src/main/java/dk/cs/aau/huppaal/controllers/HUPPAALController.java
@@ -45,6 +45,7 @@ import javafx.scene.shape.Rectangle;
 import javafx.scene.text.Text;
 import javafx.stage.DirectoryChooser;
 import javafx.stage.FileChooser;
+import javafx.stage.Screen;
 import javafx.stage.Stage;
 import javafx.util.Duration;
 import javafx.util.Pair;
@@ -215,6 +216,47 @@ public class HUPPAALController implements Initializable {
 
         // Keybind for deleting the selected elements
         KeyboardTracker.registerKeybind(KeyboardTracker.DELETE_SELECTED, new Keybind(new KeyCodeCombination(KeyCode.DELETE), this::deleteSelectedClicked));
+
+        // Register a key-bind for showing debug-information
+        KeyboardTracker.registerKeybind("DEBUG", new Keybind(new KeyCodeCombination(KeyCode.F12), () -> {
+            // Toggle the debug mode for the debug class (will update misc. debug variables which presentations bind to)
+            Debug.debugModeEnabled.set(!Debug.debugModeEnabled.get());
+
+            if (HUPPAAL.debugStage != null) {
+                HUPPAAL.debugStage.close();
+                HUPPAAL.debugStage = null;
+                return;
+            }
+
+            try {
+                final UndoRedoHistoryPresentation undoRedoHistoryPresentation = new UndoRedoHistoryPresentation();
+                undoRedoHistoryPresentation.setMinWidth(100);
+
+                final BackgroundThreadPresentation backgroundThreadPresentation = new BackgroundThreadPresentation();
+                backgroundThreadPresentation.setMinWidth(100);
+
+                final HBox root = new HBox(undoRedoHistoryPresentation, backgroundThreadPresentation);
+                root.setStyle("-fx-background-color: brown;");
+                HBox.setHgrow(undoRedoHistoryPresentation, Priority.ALWAYS);
+                HBox.setHgrow(backgroundThreadPresentation, Priority.ALWAYS);
+
+
+                HUPPAAL.debugStage = new Stage();
+                HUPPAAL.debugStage.setScene(new Scene(root));
+
+                HUPPAAL.debugStage.getScene().getStylesheets().add("main.css");
+                HUPPAAL.debugStage.getScene().getStylesheets().add("colors.css");
+
+                var vb = Screen.getPrimary().getVisualBounds();
+                HUPPAAL.debugStage.setWidth(vb.getWidth() * 0.2);
+                HUPPAAL.debugStage.setHeight(vb.getWidth() * 0.3);
+
+                HUPPAAL.debugStage.show();
+                //stage.requestFocus();
+            } catch (final Exception e) {
+                e.printStackTrace();
+            }
+        }));
 
         // Keybinds for coloring the selected elements
         EnabledColor.enabledColors.forEach(enabledColor -> {
@@ -524,6 +566,7 @@ public class HUPPAALController implements Initializable {
                     return;
                 HUPPAAL.projectDirectory.set(file.getAbsolutePath());
                 HUPPAAL.initializeProjectFolder();
+                HUPPAAL.setMainAsActiveComponent();
             } catch (final IOException e) {
                 e.printStackTrace();
             }

--- a/src/main/java/dk/cs/aau/huppaal/controllers/HUPPAALController.java
+++ b/src/main/java/dk/cs/aau/huppaal/controllers/HUPPAALController.java
@@ -218,45 +218,7 @@ public class HUPPAALController implements Initializable {
         KeyboardTracker.registerKeybind(KeyboardTracker.DELETE_SELECTED, new Keybind(new KeyCodeCombination(KeyCode.DELETE), this::deleteSelectedClicked));
 
         // Register a key-bind for showing debug-information
-        KeyboardTracker.registerKeybind("DEBUG", new Keybind(new KeyCodeCombination(KeyCode.F12), () -> {
-            // Toggle the debug mode for the debug class (will update misc. debug variables which presentations bind to)
-            Debug.debugModeEnabled.set(!Debug.debugModeEnabled.get());
-
-            if (HUPPAAL.debugStage != null) {
-                HUPPAAL.debugStage.close();
-                HUPPAAL.debugStage = null;
-                return;
-            }
-
-            try {
-                final UndoRedoHistoryPresentation undoRedoHistoryPresentation = new UndoRedoHistoryPresentation();
-                undoRedoHistoryPresentation.setMinWidth(100);
-
-                final BackgroundThreadPresentation backgroundThreadPresentation = new BackgroundThreadPresentation();
-                backgroundThreadPresentation.setMinWidth(100);
-
-                final HBox root = new HBox(undoRedoHistoryPresentation, backgroundThreadPresentation);
-                root.setStyle("-fx-background-color: brown;");
-                HBox.setHgrow(undoRedoHistoryPresentation, Priority.ALWAYS);
-                HBox.setHgrow(backgroundThreadPresentation, Priority.ALWAYS);
-
-
-                HUPPAAL.debugStage = new Stage();
-                HUPPAAL.debugStage.setScene(new Scene(root));
-
-                HUPPAAL.debugStage.getScene().getStylesheets().add("main.css");
-                HUPPAAL.debugStage.getScene().getStylesheets().add("colors.css");
-
-                var vb = Screen.getPrimary().getVisualBounds();
-                HUPPAAL.debugStage.setWidth(vb.getWidth() * 0.2);
-                HUPPAAL.debugStage.setHeight(vb.getWidth() * 0.3);
-
-                HUPPAAL.debugStage.show();
-                //stage.requestFocus();
-            } catch (final Exception e) {
-                e.printStackTrace();
-            }
-        }));
+        KeyboardTracker.registerKeybind("DEBUG", new Keybind(new KeyCodeCombination(KeyCode.F12), this::toggleDebugWindow));
 
         // Keybinds for coloring the selected elements
         EnabledColor.enabledColors.forEach(enabledColor -> {
@@ -996,6 +958,46 @@ public class HUPPAALController implements Initializable {
         } finally {
             runConfigurationExecuteButtonIcon.setIconLiteral("gmi-play-arrow");
             runConfigurationExecuteButtonIcon.setIconColor(javafx.scene.paint.Color.WHITE);
+        }
+    }
+
+    private void toggleDebugWindow() {
+        // Toggle the debug mode for the debug class (will update misc. debug variables which presentations bind to)
+        Debug.debugModeEnabled.set(!Debug.debugModeEnabled.get());
+
+        if (HUPPAAL.debugStage != null) {
+            HUPPAAL.debugStage.close();
+            HUPPAAL.debugStage = null;
+            return;
+        }
+
+        try {
+            final UndoRedoHistoryPresentation undoRedoHistoryPresentation = new UndoRedoHistoryPresentation();
+            undoRedoHistoryPresentation.setMinWidth(100);
+
+            final BackgroundThreadPresentation backgroundThreadPresentation = new BackgroundThreadPresentation();
+            backgroundThreadPresentation.setMinWidth(100);
+
+            final HBox root = new HBox(undoRedoHistoryPresentation, backgroundThreadPresentation);
+            root.setStyle("-fx-background-color: brown;");
+            HBox.setHgrow(undoRedoHistoryPresentation, Priority.ALWAYS);
+            HBox.setHgrow(backgroundThreadPresentation, Priority.ALWAYS);
+
+
+            HUPPAAL.debugStage = new Stage();
+            HUPPAAL.debugStage.setScene(new Scene(root));
+
+            HUPPAAL.debugStage.getScene().getStylesheets().add("main.css");
+            HUPPAAL.debugStage.getScene().getStylesheets().add("colors.css");
+
+            var vb = Screen.getPrimary().getVisualBounds();
+            HUPPAAL.debugStage.setWidth(vb.getWidth() * 0.2);
+            HUPPAAL.debugStage.setHeight(vb.getWidth() * 0.3);
+
+            HUPPAAL.debugStage.show();
+            //stage.requestFocus();
+        } catch (final Exception e) {
+            e.printStackTrace();
         }
     }
 

--- a/src/main/java/dk/cs/aau/huppaal/controllers/PreloaderController.java
+++ b/src/main/java/dk/cs/aau/huppaal/controllers/PreloaderController.java
@@ -1,0 +1,22 @@
+package dk.cs.aau.huppaal.controllers;
+
+import javafx.fxml.Initializable;
+import javafx.scene.control.Label;
+import javafx.scene.image.ImageView;
+import javafx.scene.layout.StackPane;
+
+import java.net.URL;
+import java.util.ResourceBundle;
+
+public class PreloaderController implements Initializable {
+
+    public StackPane root;
+    public ImageView logo;
+    public Label statusLabel;
+    public Label projectNameLabel;
+
+    @Override
+    public void initialize(URL location, ResourceBundle resources) {
+
+    }
+}

--- a/src/main/java/dk/cs/aau/huppaal/presentations/PreloaderPresentation.java
+++ b/src/main/java/dk/cs/aau/huppaal/presentations/PreloaderPresentation.java
@@ -1,0 +1,18 @@
+package dk.cs.aau.huppaal.presentations;
+
+import dk.cs.aau.huppaal.HUPPAAL;
+import dk.cs.aau.huppaal.controllers.PreloaderController;
+import javafx.scene.image.Image;
+import javafx.scene.layout.StackPane;
+
+public class PreloaderPresentation extends StackPane {
+    private final PreloaderController controller;
+    public PreloaderPresentation() {
+        controller = PresentationFxmlLoader.loadSetRoot("PreloaderPresentation.fxml", this);
+        controller.logo.setImage(new Image(HUPPAAL.class.getResource("ic_launcher/mipmap-xxxhdpi/ic_launcher.png").toExternalForm()));
+    }
+
+    public PreloaderController getController() {
+        return controller;
+    }
+}

--- a/src/main/resources/dk/cs/aau/huppaal/presentations/PreloaderPresentation.fxml
+++ b/src/main/resources/dk/cs/aau/huppaal/presentations/PreloaderPresentation.fxml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?import javafx.scene.layout.VBox?>
+<?import javafx.scene.control.Label?>
+<?import javafx.scene.layout.BorderPane?>
+<?import javafx.scene.image.ImageView?>
+<?import javafx.scene.layout.HBox?>
+<?import javafx.scene.layout.StackPane?>
+<?import com.jfoenix.controls.JFXSpinner?>
+<?import javafx.scene.layout.Region?>
+<fx:root xmlns:fx="http://javafx.com/fxml/1"
+         xmlns="http://javafx.com/javafx/8.0.76-ea"
+         type="StackPane"
+         fx:id="root"
+         fx:controller="dk.cs.aau.huppaal.controllers.PreloaderController"
+         style="-fx-padding: 25 50 25 50">
+    <BorderPane>
+        <center>
+            <ImageView fx:id="logo"/>
+        </center>
+        <bottom>
+            <VBox>
+                <HBox>
+                    <Region HBox.hgrow="ALWAYS"/>
+                    <StackPane>
+                        <JFXSpinner radius="3"/>
+                    </StackPane>
+                    <Region minWidth="5"/>
+                    <StackPane>
+                        <Label fx:id="statusLabel" styleClass="sub-caption" text="waiting"/>
+                    </StackPane>
+                    <Region minWidth="5" HBox.hgrow="ALWAYS"/>
+                </HBox>
+                <HBox>
+                    <Region HBox.hgrow="ALWAYS"/>
+                    <StackPane>
+                        <Label fx:id="projectNameLabel" styleClass="sub-caption" textFill="grey" text="project-name"/>
+                    </StackPane>
+                    <Region minWidth="5" HBox.hgrow="ALWAYS"/>
+                </HBox>
+            </VBox>
+        </bottom>
+    </BorderPane>
+</fx:root>


### PR DESCRIPTION
## v1.4.0-rc1 feedback
Related Issue: #56 
Loading projects can take a very long time, and with no indication of wether the project is loading or not it is easy to think that the program is simply not starting at all. This may lead accidental double-openings of the editor, making the situation worse.

This PR adds a [javafx preloader](https://docs.oracle.com/javafx/2/deployment/preloaders.htm#BABJDJDJ) splash-screen style loader to mitigate this issue.

https://user-images.githubusercontent.com/4085393/206157284-35297fa4-3a2c-4f83-a7ea-aa23b424d503.mov

## Limitations
Note that this does not _solve_ slow loading times, it simply mitigates user frustration. Also, please note that this splashscreen only appears when the editor _starts_ - not when you load a different project.